### PR TITLE
Add an endpoint to get customer portal urls

### DIFF
--- a/src/integrationTest/java/com/trynoice/api/sound/SoundControllerTest.java
+++ b/src/integrationTest/java/com/trynoice/api/sound/SoundControllerTest.java
@@ -1,11 +1,8 @@
 package com.trynoice.api.sound;
 
-import com.trynoice.api.identity.entities.AuthUser;
-import com.trynoice.api.subscription.entities.Customer;
-import com.trynoice.api.subscription.entities.Subscription;
+import com.trynoice.api.subscription.SubscriptionTestUtils;
 import com.trynoice.api.subscription.entities.SubscriptionPlan;
 import com.trynoice.api.testing.AuthTestUtils;
-import lombok.NonNull;
 import lombok.val;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -27,8 +24,6 @@ import javax.persistence.EntityManager;
 import javax.transaction.Transactional;
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
-import java.time.OffsetDateTime;
-import java.util.UUID;
 import java.util.stream.Stream;
 
 import static com.trynoice.api.testing.AuthTestUtils.createAuthUser;
@@ -106,7 +101,8 @@ public class SoundControllerTest {
 
         val authUser = createAuthUser(entityManager);
         if (isSubscribed != null) {
-            buildSubscription(authUser, isSubscribed, isPaymentPending);
+            val plan = SubscriptionTestUtils.buildSubscriptionPlan(entityManager, SubscriptionPlan.Provider.STRIPE, "test-id");
+            SubscriptionTestUtils.buildSubscription(entityManager, authUser, plan, isSubscribed, isPaymentPending, "test-id");
         }
 
         val requestUrlFmt = "/v1/sounds/{soundId}/segments/{segmentId}/authorize?audioBitrate={bitrate}&libraryVersion={libraryVersion}";
@@ -133,39 +129,5 @@ public class SoundControllerTest {
             arguments(true, true, true, HttpStatus.NO_CONTENT.value()),
             arguments(true, true, false, HttpStatus.NO_CONTENT.value())
         );
-    }
-
-    private void buildSubscription(@NonNull AuthUser owner, boolean isActive, boolean isPaymentPending) {
-        val customer = Customer.builder()
-            .userId(owner.getId())
-            .stripeId(UUID.randomUUID().toString())
-            .build();
-
-        entityManager.persist(customer);
-
-        val subscription = Subscription.builder()
-            .customer(customer)
-            .plan(buildSubscriptionPlan())
-            .providedId(UUID.randomUUID().toString())
-            .isPaymentPending(isPaymentPending)
-            .startAt(OffsetDateTime.now().plusHours(-2))
-            .endAt(OffsetDateTime.now().plusHours(isActive ? 2 : -1))
-            .build();
-
-        entityManager.persist(subscription);
-    }
-
-    @NonNull
-    private SubscriptionPlan buildSubscriptionPlan() {
-        val plan = SubscriptionPlan.builder()
-            .provider(SubscriptionPlan.Provider.STRIPE)
-            .providedId(UUID.randomUUID().toString().substring(0, 16))
-            .billingPeriodMonths((short) 1)
-            .trialPeriodDays((short) 1)
-            .priceInIndianPaise(10000)
-            .build();
-
-        entityManager.persist(plan);
-        return plan;
     }
 }

--- a/src/integrationTest/java/com/trynoice/api/sound/SoundControllerTest.java
+++ b/src/integrationTest/java/com/trynoice/api/sound/SoundControllerTest.java
@@ -146,7 +146,7 @@ public class SoundControllerTest {
         val subscription = Subscription.builder()
             .customer(customer)
             .plan(buildSubscriptionPlan())
-            .providerSubscriptionId(UUID.randomUUID().toString())
+            .providedId(UUID.randomUUID().toString())
             .isPaymentPending(isPaymentPending)
             .startAt(OffsetDateTime.now().plusHours(-2))
             .endAt(OffsetDateTime.now().plusHours(isActive ? 2 : -1))
@@ -159,7 +159,7 @@ public class SoundControllerTest {
     private SubscriptionPlan buildSubscriptionPlan() {
         val plan = SubscriptionPlan.builder()
             .provider(SubscriptionPlan.Provider.STRIPE)
-            .providerPlanId(UUID.randomUUID().toString().substring(0, 16))
+            .providedId(UUID.randomUUID().toString().substring(0, 16))
             .billingPeriodMonths((short) 1)
             .trialPeriodDays((short) 1)
             .priceInIndianPaise(10000)

--- a/src/integrationTest/java/com/trynoice/api/subscription/SubscriptionControllerV2Test.java
+++ b/src/integrationTest/java/com/trynoice/api/subscription/SubscriptionControllerV2Test.java
@@ -1,0 +1,330 @@
+package com.trynoice.api.subscription;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.stripe.model.checkout.Session;
+import com.trynoice.api.identity.entities.AuthUser;
+import com.trynoice.api.subscription.ecb.ForeignExchangeRatesProvider;
+import com.trynoice.api.subscription.entities.CustomerRepository;
+import com.trynoice.api.subscription.entities.GiftCardRepository;
+import com.trynoice.api.subscription.entities.Subscription;
+import com.trynoice.api.subscription.entities.SubscriptionPlan;
+import com.trynoice.api.subscription.entities.SubscriptionPlanRepository;
+import com.trynoice.api.subscription.entities.SubscriptionRepository;
+import com.trynoice.api.subscription.payload.SubscriptionFlowParams;
+import com.trynoice.api.testing.AuthTestUtils;
+import lombok.NonNull;
+import lombok.val;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import javax.persistence.EntityManager;
+import javax.transaction.Transactional;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static com.trynoice.api.subscription.SubscriptionTestUtils.buildCustomer;
+import static com.trynoice.api.subscription.SubscriptionTestUtils.buildGiftCard;
+import static com.trynoice.api.subscription.SubscriptionTestUtils.buildSubscription;
+import static com.trynoice.api.subscription.SubscriptionTestUtils.buildSubscriptionPlan;
+import static com.trynoice.api.testing.AuthTestUtils.createAuthUser;
+import static com.trynoice.api.testing.AuthTestUtils.createSignedAccessJwt;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+public class SubscriptionControllerV2Test {
+
+    @Value("${app.auth.hmac-secret}")
+    private String hmacSecret;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Autowired
+    private CustomerRepository customerRepository;
+
+    @Autowired
+    private SubscriptionPlanRepository subscriptionPlanRepository;
+
+    @Autowired
+    private SubscriptionRepository subscriptionRepository;
+
+    @Autowired
+    private GiftCardRepository giftCardRepository;
+
+    @MockBean
+    private StripeApi stripeApi;
+
+    @MockBean
+    private ForeignExchangeRatesProvider exchangeRatesProvider;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @ParameterizedTest
+    @MethodSource("createSubscriptionTestCases")
+    void createSubscription(
+        @NonNull SubscriptionPlan.Provider provider,
+        Boolean wasSubscriptionActive,
+        int expectedResponseStatus
+    ) throws Exception {
+        val providedId = "provided-id";
+        val successUrl = "https://api.test/success";
+        val cancelUrl = "https://api.test/cancel";
+        val authUser = createAuthUser(entityManager);
+        val plan = buildSubscriptionPlan(entityManager, provider, providedId);
+        if (wasSubscriptionActive != null) {
+            buildSubscription(entityManager, authUser, plan, wasSubscriptionActive, false, null);
+        }
+
+        val mockSession = mock(Session.class);
+        val sessionUrl = "/checkout-session-url";
+        if (provider == SubscriptionPlan.Provider.STRIPE) {
+            val customer = buildCustomer(entityManager, authUser);
+            when(mockSession.getUrl()).thenReturn(sessionUrl);
+            when(
+                stripeApi.createCheckoutSession(
+                    eq(successUrl),
+                    eq(cancelUrl),
+                    eq(plan.getProvidedId()),
+                    any(),
+                    eq(null),
+                    eq(customer.getStripeId()),
+                    any()))
+                .thenReturn(mockSession);
+        }
+
+        val params = objectMapper.writeValueAsString(new SubscriptionFlowParams(plan.getId(), successUrl, cancelUrl));
+        val resultActions = mockMvc.perform(
+                post("/v2/subscriptions")
+                    .header("Authorization", "bearer " + createSignedAccessJwt(hmacSecret, authUser, AuthTestUtils.JwtType.VALID))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(params))
+            .andExpect(status().is(expectedResponseStatus));
+
+        if (expectedResponseStatus == HttpStatus.CREATED.value()) {
+            resultActions.andExpect(jsonPath("$.subscriptionId").isNumber());
+            if (provider == SubscriptionPlan.Provider.STRIPE) {
+                resultActions.andExpect(jsonPath("$.stripeCheckoutSessionUrl").isString());
+            }
+        }
+    }
+
+    static Stream<Arguments> createSubscriptionTestCases() {
+        return Stream.of(
+            // provider, is existing subscription active, response status
+            arguments(SubscriptionPlan.Provider.GOOGLE_PLAY, null, HttpStatus.CREATED.value()),
+            arguments(SubscriptionPlan.Provider.STRIPE, null, HttpStatus.CREATED.value()),
+            arguments(SubscriptionPlan.Provider.GOOGLE_PLAY, false, HttpStatus.CREATED.value()),
+            arguments(SubscriptionPlan.Provider.STRIPE, false, HttpStatus.CREATED.value()),
+            arguments(SubscriptionPlan.Provider.GOOGLE_PLAY, true, HttpStatus.CONFLICT.value()),
+            arguments(SubscriptionPlan.Provider.STRIPE, true, HttpStatus.CONFLICT.value())
+        );
+    }
+
+    @Test
+    void listSubscriptions() throws Exception {
+        val subscriptionPlan = buildSubscriptionPlan(entityManager, SubscriptionPlan.Provider.GOOGLE_PLAY, "test-provider-id");
+        val data = new HashMap<AuthUser, List<Subscription>>();
+        for (int i = 0; i < 5; i++) {
+            val authUser = createAuthUser(entityManager);
+            val subscriptions = new ArrayList<Subscription>(5);
+            for (int j = 0; j < 5; j++) {
+                subscriptions.add(buildSubscription(entityManager, authUser, subscriptionPlan, true, false, null));
+            }
+
+            val unstarted = buildSubscription(entityManager, authUser, subscriptionPlan, false, false, null);
+            unstarted.setStartAt(null);
+            unstarted.setEndAt(null);
+            subscriptions.add(subscriptionRepository.save(unstarted));
+
+            data.put(authUser, subscriptions);
+        }
+
+        for (val entry : data.entrySet()) {
+            val addCurrencyParam = entry.getKey().getId() % 2 == 0;
+            val accessToken = createSignedAccessJwt(hmacSecret, entry.getKey(), AuthTestUtils.JwtType.VALID);
+            val requestBuilder = get("/v2/subscriptions")
+                .header("Authorization", "Bearer " + accessToken);
+
+            if (addCurrencyParam) {
+                val currency = "USD";
+                requestBuilder.queryParam("currency", currency);
+                when(exchangeRatesProvider.getRateForCurrency(any(), eq(currency)))
+                    .thenReturn(Optional.of(1.0));
+            }
+
+            val result = mockMvc.perform(requestBuilder)
+                .andExpect(status().is(HttpStatus.OK.value()))
+                .andReturn();
+
+            val expectedIds = entry.getValue()
+                .stream()
+                .filter(s -> s.getStartAt() != null)
+                .map(s -> String.valueOf(s.getId()))
+                .sorted()
+                .collect(Collectors.toList());
+
+            val actualSubscriptions = objectMapper.readValue(result.getResponse().getContentAsByteArray(), JsonNode[].class);
+            val actualIds = Arrays.stream(actualSubscriptions)
+                .map(v -> v.findValue("id").asText())
+                .sorted()
+                .collect(Collectors.toList());
+
+            assertEquals(expectedIds, actualIds);
+            for (val actualSubscription : actualSubscriptions) {
+                val priceInRequestedCurrencyNode = actualSubscription.at("/plan/priceInRequestedCurrency");
+                if (addCurrencyParam) {
+                    assertTrue(priceInRequestedCurrencyNode.isNumber());
+                } else {
+                    assertTrue(priceInRequestedCurrencyNode.isMissingNode() || priceInRequestedCurrencyNode.isNull());
+                }
+            }
+        }
+    }
+
+    @Test
+    void listSubscriptions_pagination() throws Exception {
+        val subscriptionPlan = buildSubscriptionPlan(entityManager, SubscriptionPlan.Provider.GOOGLE_PLAY, "test-provider-id");
+        val owner = createAuthUser(entityManager);
+        for (int j = 0; j < 25; j++) {
+            buildSubscription(entityManager, owner, subscriptionPlan, true, false, null);
+        }
+
+        val pageSizes = Map.of(0, 20, 1, 5);
+        val accessToken = createSignedAccessJwt(hmacSecret, owner, AuthTestUtils.JwtType.VALID);
+        for (var entry : pageSizes.entrySet()) {
+            mockMvc.perform(
+                    get("/v2/subscriptions")
+                        .queryParam("page", entry.getKey().toString())
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().is(HttpStatus.OK.value()))
+                .andExpect(jsonPath("$.length()").value(entry.getValue()));
+        }
+
+        mockMvc.perform(
+                get("/v2/subscriptions")
+                    .queryParam("page", "2")
+                    .header("Authorization", "Bearer " + accessToken))
+            .andExpect(status().is(HttpStatus.OK.value()))
+            .andExpect(jsonPath("$.length()").value(0));
+    }
+
+    @Test
+    void getSubscription() throws Exception {
+        val owner = createAuthUser(entityManager);
+        val impersonator = createAuthUser(entityManager);
+        val plan = buildSubscriptionPlan(entityManager, SubscriptionPlan.Provider.STRIPE, "test-provider-id");
+        val subscription = buildSubscription(entityManager, owner, plan, false, false, null);
+
+        val impersonatorToken = createSignedAccessJwt(hmacSecret, impersonator, AuthTestUtils.JwtType.VALID);
+        doGetSubscriptionRequest(impersonatorToken, subscription.getId(), null)
+            .andExpect(status().is(HttpStatus.NOT_FOUND.value()));
+
+        val ownerAccessToken = createSignedAccessJwt(hmacSecret, owner, AuthTestUtils.JwtType.VALID);
+        doGetSubscriptionRequest(ownerAccessToken, subscription.getId(), null)
+            .andExpect(status().is(HttpStatus.OK.value()))
+            .andExpect(jsonPath("$.id").value(subscription.getId()));
+
+        val currency = "USD";
+        when(exchangeRatesProvider.getRateForCurrency(any(), eq(currency)))
+            .thenReturn(Optional.of(1.0));
+        doGetSubscriptionRequest(ownerAccessToken, subscription.getId(), currency)
+            .andExpect(status().is(HttpStatus.OK.value()))
+            .andExpect(jsonPath("$.plan.priceInRequestedCurrency").isNumber());
+
+        val unstartedSubscription = buildSubscription(entityManager, owner, plan, false, false, null);
+        unstartedSubscription.setStartAt(null);
+        unstartedSubscription.setEndAt(null);
+        subscriptionRepository.save(unstartedSubscription);
+        doGetSubscriptionRequest(ownerAccessToken, unstartedSubscription.getId(), null)
+            .andExpect(status().is(HttpStatus.NOT_FOUND.value()));
+    }
+
+    private ResultActions doGetSubscriptionRequest(String accessToken, long subscriptionId, String currency) throws Exception {
+        val requestBuilder = get("/v2/subscriptions/{subscriptionId}", subscriptionId)
+            .header("Authorization", "Bearer " + accessToken);
+        if (currency != null) {
+            requestBuilder.queryParam("currency", currency);
+        }
+
+        return mockMvc.perform(requestBuilder);
+    }
+
+    @ParameterizedTest
+    @MethodSource("redeemGiftCardTestCases")
+    void redeemGiftCard(
+        boolean exists,
+        Boolean owned,
+        boolean redeemed,
+        Boolean expired,
+        boolean subscribed,
+        int expectedResponseStatus
+    ) throws Exception {
+        val code = "test-gift-card-2";
+        val authUser = createAuthUser(entityManager);
+        if (exists) {
+            val owner = owned == null ? null : buildCustomer(entityManager, owned ? authUser : createAuthUser(entityManager));
+            buildGiftCard(entityManager, code, owner, redeemed, expired);
+        }
+
+        if (subscribed) {
+            val plan = buildSubscriptionPlan(entityManager, SubscriptionPlan.Provider.STRIPE, "test-plan");
+            buildSubscription(entityManager, authUser, plan, true, false, "test-sub");
+        }
+
+        val accessToken = createSignedAccessJwt(hmacSecret, authUser, AuthTestUtils.JwtType.VALID);
+        mockMvc.perform(
+                post("/v2/subscriptions/giftCards/{code}/redeem", code)
+                    .header("Authorization", "Bearer " + accessToken))
+            .andExpect(status().is(expectedResponseStatus));
+    }
+
+    static Stream<Arguments> redeemGiftCardTestCases() {
+        return Stream.of(
+            // exists, owned, redeemed, expired, subscribed, response status
+            arguments(false, null, false, false, false, HttpStatus.NOT_FOUND.value()),
+            arguments(true, false, false, false, false, HttpStatus.NOT_FOUND.value()),
+            arguments(true, null, false, false, false, HttpStatus.CREATED.value()),
+            arguments(true, true, false, false, false, HttpStatus.CREATED.value()),
+            arguments(true, null, true, false, false, HttpStatus.UNPROCESSABLE_ENTITY.value()),
+            arguments(true, true, true, false, false, HttpStatus.UNPROCESSABLE_ENTITY.value()),
+            arguments(true, false, true, false, false, HttpStatus.NOT_FOUND.value()),
+            arguments(true, true, false, true, false, HttpStatus.GONE.value()),
+            arguments(true, true, false, null, false, HttpStatus.CREATED.value()),
+            arguments(true, true, false, false, true, HttpStatus.CONFLICT.value())
+        );
+    }
+}

--- a/src/integrationTest/java/com/trynoice/api/subscription/SubscriptionServiceTest.java
+++ b/src/integrationTest/java/com/trynoice/api/subscription/SubscriptionServiceTest.java
@@ -79,7 +79,7 @@ public class SubscriptionServiceTest {
 
         assertEquals(isActive, subscription.isActive());
         assertEquals(isPaymentPending, subscription.isPaymentPending());
-        assertEquals(purchaseToken, subscription.getProviderSubscriptionId());
+        assertEquals(purchaseToken, subscription.getProvidedId());
         assertTrue(subscription.getCustomer().isTrialPeriodUsed());
 
         verify(androidPublisherApi, times(shouldAcknowledgePurchase ? 1 : 0))
@@ -158,7 +158,7 @@ public class SubscriptionServiceTest {
         val authUser = createAuthUser(entityManager);
         val subscription = buildSubscription(authUser, oldPlan, true, false, oldPurchaseToken);
         val purchase = GooglePlaySubscriptionPurchase.builder()
-            .productId(newPlan.getProviderPlanId())
+            .productId(newPlan.getProvidedId())
             .startTimeMillis(System.currentTimeMillis())
             .expiryTimeMillis(System.currentTimeMillis() + 60 * 60 * 1000L)
             .isPaymentPending(false)
@@ -176,8 +176,8 @@ public class SubscriptionServiceTest {
                 GooglePlayDeveloperNotification.SubscriptionNotification.TYPE_RENEWED,
                 newPurchaseToken));
 
-        assertEquals(newPlan.getProviderPlanId(), subscription.getPlan().getProviderPlanId());
-        assertEquals(newPurchaseToken, subscription.getProviderSubscriptionId());
+        assertEquals(newPlan.getProvidedId(), subscription.getPlan().getProvidedId());
+        assertEquals(newPurchaseToken, subscription.getProvidedId());
     }
 
     @Test
@@ -190,7 +190,7 @@ public class SubscriptionServiceTest {
         val subscription1 = buildSubscription(authUser, plan, true, false, UUID.randomUUID().toString());
         val subscription2 = buildSubscription(authUser, plan, false, false, null);
         val purchase = GooglePlaySubscriptionPurchase.builder()
-            .productId(plan.getProviderPlanId())
+            .productId(plan.getProvidedId())
             .startTimeMillis(System.currentTimeMillis())
             .expiryTimeMillis(System.currentTimeMillis() * 60 * 60 * 1000L)
             .isPaymentPending(true)
@@ -209,14 +209,14 @@ public class SubscriptionServiceTest {
 
         assertTrue(subscription1.isActive());
         assertFalse(subscription2.isActive());
-        verify(androidPublisherApi, times(0)).acknowledgePurchase(plan.getProviderPlanId(), purchaseToken);
+        verify(androidPublisherApi, times(0)).acknowledgePurchase(plan.getProvidedId(), purchaseToken);
     }
 
     @NonNull
-    private SubscriptionPlan buildSubscriptionPlan(@NonNull String providerPlanId) {
+    private SubscriptionPlan buildSubscriptionPlan(@NonNull String providedId) {
         val plan = SubscriptionPlan.builder()
             .provider(SubscriptionPlan.Provider.GOOGLE_PLAY)
-            .providerPlanId(providerPlanId)
+            .providedId(providedId)
             .billingPeriodMonths((short) 1)
             .trialPeriodDays((short) 1)
             .priceInIndianPaise(10000)
@@ -232,7 +232,7 @@ public class SubscriptionServiceTest {
         @NonNull SubscriptionPlan plan,
         boolean isActive,
         boolean isPaymentPending,
-        String providerSubscriptionId
+        String providedId
     ) {
         return subscriptionRepository.save(
             Subscription.builder()
@@ -242,7 +242,7 @@ public class SubscriptionServiceTest {
                             .userId(owner.getId())
                             .build()))
                 .plan(plan)
-                .providerSubscriptionId(providerSubscriptionId)
+                .providedId(providedId)
                 .isPaymentPending(isPaymentPending)
                 .startAt(OffsetDateTime.now().plusHours(-2))
                 .endAt(OffsetDateTime.now().plusHours(isActive ? 2 : -1))

--- a/src/integrationTest/java/com/trynoice/api/subscription/SubscriptionTestUtils.java
+++ b/src/integrationTest/java/com/trynoice/api/subscription/SubscriptionTestUtils.java
@@ -27,7 +27,7 @@ import static org.mockito.Mockito.mock;
 public class SubscriptionTestUtils {
 
     @NonNull
-    static SubscriptionPlan buildSubscriptionPlan(
+    public static SubscriptionPlan buildSubscriptionPlan(
         @NonNull EntityManager entityManager,
         @NonNull SubscriptionPlan.Provider provider,
         @NonNull String providedId
@@ -44,7 +44,7 @@ public class SubscriptionTestUtils {
     }
 
     @NonNull
-    static Subscription buildSubscription(
+    public static Subscription buildSubscription(
         @NonNull EntityManager entityManager,
         @NonNull AuthUser owner,
         @NonNull SubscriptionPlan plan,

--- a/src/integrationTest/java/com/trynoice/api/subscription/SubscriptionTestUtils.java
+++ b/src/integrationTest/java/com/trynoice/api/subscription/SubscriptionTestUtils.java
@@ -1,0 +1,151 @@
+package com.trynoice.api.subscription;
+
+import com.stripe.model.Event;
+import com.stripe.model.EventDataObjectDeserializer;
+import com.stripe.model.Price;
+import com.stripe.model.StripeObject;
+import com.stripe.model.SubscriptionItem;
+import com.stripe.model.SubscriptionItemCollection;
+import com.stripe.model.checkout.Session;
+import com.trynoice.api.identity.entities.AuthUser;
+import com.trynoice.api.subscription.entities.Customer;
+import com.trynoice.api.subscription.entities.GiftCard;
+import com.trynoice.api.subscription.entities.Subscription;
+import com.trynoice.api.subscription.entities.SubscriptionPlan;
+import lombok.NonNull;
+import lombok.val;
+
+import javax.persistence.EntityManager;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+
+public class SubscriptionTestUtils {
+
+    @NonNull
+    static SubscriptionPlan buildSubscriptionPlan(
+        @NonNull EntityManager entityManager,
+        @NonNull SubscriptionPlan.Provider provider,
+        @NonNull String providedId
+    ) {
+        val plan = SubscriptionPlan.builder()
+            .provider(provider)
+            .providedId(providedId)
+            .billingPeriodMonths((short) 1)
+            .trialPeriodDays((short) 1)
+            .priceInIndianPaise(10000)
+            .build();
+
+        return entityManager.merge(plan);
+    }
+
+    @NonNull
+    static Subscription buildSubscription(
+        @NonNull EntityManager entityManager,
+        @NonNull AuthUser owner,
+        @NonNull SubscriptionPlan plan,
+        boolean isActive,
+        boolean isPaymentPending,
+        String providedId
+    ) {
+        val subscription = Subscription.builder()
+            .customer(buildCustomer(entityManager, owner))
+            .plan(plan)
+            .providedId(providedId)
+            .isPaymentPending(isPaymentPending)
+            .startAt(OffsetDateTime.now().plusHours(-2))
+            .endAt(OffsetDateTime.now().plusHours(isActive ? 2 : -1))
+            .build();
+
+        return entityManager.merge(subscription);
+    }
+
+    @NonNull
+    static Customer buildCustomer(@NonNull EntityManager entityManager, @NonNull AuthUser user) {
+        val customer = Customer.builder()
+            .userId(user.getId())
+            .stripeId(UUID.randomUUID().toString())
+            .build();
+
+        return entityManager.merge(customer);
+    }
+
+    @NonNull
+    static GiftCard buildGiftCard(
+        @NonNull EntityManager entityManager,
+        @NonNull String code,
+        Customer customer,
+        boolean isRedeemed,
+        Boolean isExpired
+    ) {
+        val giftCard = GiftCard.builder()
+            .code(code)
+            .hourCredits((short) 1)
+            .plan(buildSubscriptionPlan(entityManager, SubscriptionPlan.Provider.GIFT_CARD, "gift-card"))
+            .customer(customer)
+            .isRedeemed(isRedeemed)
+            .expiresAt(isExpired == null ? null : OffsetDateTime.now().plusHours(isExpired ? -1 : 1))
+            .build();
+
+        return entityManager.merge(giftCard);
+    }
+
+    @NonNull
+    static Event buildStripeEvent(@NonNull String type, @NonNull StripeObject dataObject) {
+        // TODO: maybe find a fix in free time.
+        // mock because event data object serialization/deserialization is confusing and all my
+        // attempts failed.
+        val event = mock(Event.class);
+        lenient().when(event.getType()).thenReturn(type);
+
+        val deserializer = mock(EventDataObjectDeserializer.class);
+        lenient().when(deserializer.getObject()).thenReturn(Optional.of(dataObject));
+        lenient().when(event.getDataObjectDeserializer()).thenReturn(deserializer);
+
+        lenient().when(event.toJson()).thenReturn("{}");
+        return event;
+    }
+
+    @NonNull
+    static Session buildStripeCheckoutSession(@NonNull String status, @NonNull String paymentStatus, String clientReferenceId) {
+        val session = new Session();
+        session.setMode("subscription");
+        session.setStatus(status);
+        session.setPaymentStatus(paymentStatus);
+        session.setSubscription(UUID.randomUUID().toString());
+        session.setCustomer(UUID.randomUUID().toString());
+        session.setClientReferenceId(clientReferenceId);
+        return session;
+    }
+
+    @NonNull
+    static com.stripe.model.Subscription buildStripeSubscription(String id, @NonNull String status, @NonNull String priceId) {
+        val subscription = new com.stripe.model.Subscription();
+        subscription.setId(id);
+        subscription.setStatus(status);
+
+        val now = OffsetDateTime.now().toEpochSecond();
+        subscription.setCurrentPeriodStart(now);
+        subscription.setStartDate(now);
+        subscription.setCurrentPeriodEnd(now + 60 * 60);
+
+        val items = new SubscriptionItemCollection();
+        items.setData(List.of(buildSubscriptionItem(priceId)));
+        subscription.setItems(items);
+        return subscription;
+    }
+
+    @NonNull
+    static SubscriptionItem buildSubscriptionItem(@NonNull String priceId) {
+        val price = new Price();
+        price.setId(priceId);
+
+        val subscriptionItem = new SubscriptionItem();
+        subscriptionItem.setPrice(price);
+        return subscriptionItem;
+    }
+}

--- a/src/integrationTest/java/com/trynoice/api/testing/AuthTestUtils.java
+++ b/src/integrationTest/java/com/trynoice/api/testing/AuthTestUtils.java
@@ -31,13 +31,10 @@ public class AuthTestUtils {
     @NonNull
     public static AuthUser createAuthUser(@NonNull EntityManager entityManager) {
         val uuid = UUID.randomUUID().toString();
-        val authUser = AuthUser.builder()
+        return entityManager.merge(AuthUser.builder()
             .name(uuid)
             .email(uuid + "@api.test")
-            .build();
-
-        entityManager.persist(authUser);
-        return authUser;
+            .build());
     }
 
     /**
@@ -49,14 +46,11 @@ public class AuthTestUtils {
      */
     @NonNull
     public static RefreshToken createRefreshToken(@NonNull EntityManager entityManager, @NonNull AuthUser owner) {
-        val refreshToken = RefreshToken.builder()
+        return entityManager.merge(RefreshToken.builder()
             .expiresAt(OffsetDateTime.now().plus(Duration.ofHours(1)))
             .userAgent("")
             .owner(owner)
-            .build();
-
-        entityManager.persist(refreshToken);
-        return refreshToken;
+            .build());
     }
 
     /**
@@ -89,13 +83,12 @@ public class AuthTestUtils {
                 break;
         }
 
-        val refreshToken = RefreshToken.builder()
-            .expiresAt(expiresAt)
-            .userAgent("")
-            .owner(owner)
-            .build();
-
-        entityManager.persist(refreshToken);
+        val refreshToken = entityManager.merge(
+            RefreshToken.builder()
+                .expiresAt(expiresAt)
+                .userAgent("")
+                .owner(owner)
+                .build());
 
         val jwtSigningAlgorithm = Algorithm.HMAC256(hmacSecret);
         if (type != JwtType.REUSED) {

--- a/src/main/java/com/trynoice/api/Application.java
+++ b/src/main/java/com/trynoice/api/Application.java
@@ -140,7 +140,7 @@ public class Application {
         // use request filter to use SecurityContext for authorizing requests.
         http.authorizeRequests()
             .mvcMatchers(HttpMethod.GET, "/v1/sounds/*/segments/*/authorize").permitAll()
-            .antMatchers("/v1/**").fullyAuthenticated()
+            .antMatchers("/v?*/**").fullyAuthenticated()
             .anyRequest().permitAll();
 
         // add custom filter to set SecurityContext based on Authorization bearer JWT.

--- a/src/main/java/com/trynoice/api/Application.java
+++ b/src/main/java/com/trynoice/api/Application.java
@@ -29,7 +29,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.http.HttpMethod;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.AnonymousAuthenticationFilter;
 import org.springframework.stereotype.Component;
@@ -101,18 +100,6 @@ public class Application {
     }
 
     @Bean
-    public WebSecurityCustomizer webSecurityCustomizer() {
-        // exclude URLs from the Spring security filter chain.
-        return (web) -> web.ignoring()
-            .mvcMatchers(HttpMethod.POST, "/v1/accounts/signUp")
-            .mvcMatchers(HttpMethod.POST, "/v1/accounts/signIn")
-            .mvcMatchers(HttpMethod.GET, "/v1/accounts/credentials")
-            .mvcMatchers(HttpMethod.GET, "/v1/subscriptions/plans")
-            .mvcMatchers(HttpMethod.POST, "/v1/subscriptions/googlePlay/webhook")
-            .mvcMatchers(HttpMethod.POST, "/v1/subscriptions/stripe/webhook");
-    }
-
-    @Bean
     public SecurityFilterChain securityFilterChain(
         @NonNull HttpSecurity http,
         @NonNull BearerTokenAuthFilter bearerTokenAuthFilter,
@@ -140,6 +127,12 @@ public class Application {
         // use request filter to use SecurityContext for authorizing requests.
         http.authorizeRequests()
             .mvcMatchers(HttpMethod.GET, "/v1/sounds/*/segments/*/authorize").permitAll()
+            .mvcMatchers(HttpMethod.GET, "/v1/subscriptions/plans").permitAll()
+            .mvcMatchers(HttpMethod.POST, "/v1/accounts/signUp").anonymous()
+            .mvcMatchers(HttpMethod.POST, "/v1/accounts/signIn").anonymous()
+            .mvcMatchers(HttpMethod.GET, "/v1/accounts/credentials").anonymous()
+            .mvcMatchers(HttpMethod.POST, "/v1/subscriptions/googlePlay/webhook").anonymous()
+            .mvcMatchers(HttpMethod.POST, "/v1/subscriptions/stripe/webhook").anonymous()
             .antMatchers("/v?*/**").fullyAuthenticated()
             .anyRequest().permitAll();
 

--- a/src/main/java/com/trynoice/api/subscription/SubscriptionController.java
+++ b/src/main/java/com/trynoice/api/subscription/SubscriptionController.java
@@ -130,6 +130,7 @@ class SubscriptionController {
      *
      * @param params {@code successUrl} and {@code cancelUrl} are only required for Stripe plans.
      */
+    @Deprecated
     @Operation(summary = "Initiate the subscription flow")
     @ApiResponses({
         @ApiResponse(responseCode = "201", description = "subscription flow successfully initiated"),
@@ -145,8 +146,12 @@ class SubscriptionController {
         @Valid @NotNull @RequestBody SubscriptionFlowParams params
     ) {
         try {
-            val response = subscriptionService.createSubscription(principalId, params);
-            return ResponseEntity.status(HttpStatus.CREATED).body(response);
+            val responseV2 = subscriptionService.createSubscription(principalId, params);
+            return ResponseEntity.status(HttpStatus.CREATED)
+                .body(SubscriptionFlowResponse.builder()
+                    .subscription(responseV2.getSubscription())
+                    .stripeCheckoutSessionUrl(responseV2.getStripeCheckoutSessionUrl())
+                    .build());
         } catch (SubscriptionPlanNotFoundException e) {
             return ResponseEntity.badRequest().build();
         } catch (DuplicateSubscriptionException e) {

--- a/src/main/java/com/trynoice/api/subscription/SubscriptionControllerV2.java
+++ b/src/main/java/com/trynoice/api/subscription/SubscriptionControllerV2.java
@@ -1,9 +1,15 @@
 package com.trynoice.api.subscription;
 
+import com.trynoice.api.platform.validation.annotations.NullOrNotBlank;
 import com.trynoice.api.subscription.exceptions.DuplicateSubscriptionException;
+import com.trynoice.api.subscription.exceptions.GiftCardExpiredException;
+import com.trynoice.api.subscription.exceptions.GiftCardNotFoundException;
+import com.trynoice.api.subscription.exceptions.GiftCardRedeemedException;
+import com.trynoice.api.subscription.exceptions.SubscriptionNotFoundException;
 import com.trynoice.api.subscription.exceptions.SubscriptionPlanNotFoundException;
 import com.trynoice.api.subscription.payload.SubscriptionFlowParams;
 import com.trynoice.api.subscription.payload.SubscriptionFlowResponseV2;
+import com.trynoice.api.subscription.payload.SubscriptionResponseV2;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -17,13 +23,20 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.validation.Valid;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+import java.util.List;
 
 @Validated
 @RestController
@@ -86,6 +99,103 @@ public class SubscriptionControllerV2 {
             return ResponseEntity.badRequest().build();
         } catch (DuplicateSubscriptionException e) {
             return ResponseEntity.status(HttpStatus.CONFLICT).build();
+        }
+    }
+
+    /**
+     * Lists a {@code page} of subscriptions purchased by the authenticated user. Each {@code page}
+     * contains at-most 20 entries. If {@code onlyActive} is {@literal true}, it lists the currently
+     * active subscription purchase (at most one). It doesn't return subscription entities that were
+     * initiated, but were never started.
+     *
+     * @param onlyActive return only the active subscription (single instance).
+     * @param currency   an optional ISO 4217 currency code for including converted prices with the
+     *                   subscription's plan.
+     * @param page       0-indexed page number.
+     * @return a list of subscription purchases; empty list if the page number is higher than
+     * available data.
+     */
+    @Operation(summary = "List subscriptions")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200"),
+        @ApiResponse(responseCode = "400", description = "request is not valid", content = @Content),
+        @ApiResponse(responseCode = "401", description = "access token is invalid", content = @Content),
+        @ApiResponse(responseCode = "500", description = "internal server error", content = @Content),
+    })
+    @NonNull
+    @GetMapping
+    ResponseEntity<List<SubscriptionResponseV2>> listSubscriptions(
+        @NonNull @AuthenticationPrincipal Long principalId,
+        @Valid @NotNull @RequestParam(required = false, defaultValue = "false") Boolean onlyActive,
+        @Valid @NullOrNotBlank @Size(min = 3, max = 3) @RequestParam(value = "currency", required = false) String currency,
+        @Valid @NotNull @Min(0) @RequestParam(required = false, defaultValue = "0") Integer page
+    ) {
+        return ResponseEntity.ok(subscriptionService.listSubscriptions(principalId, onlyActive, currency, page));
+    }
+
+    /**
+     * Get a subscription purchased by the authenticated user by its {@code subscriptionId}. It
+     * doesn't return subscription entities that were initiated, but were never started.
+     *
+     * @param currency an optional ISO 4217 currency code for including converted prices with the
+     *                 subscription's plan.
+     * @return the requested subscription.
+     */
+    @Operation(summary = "Get subscription")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200"),
+        @ApiResponse(responseCode = "400", description = "request is not valid", content = @Content),
+        @ApiResponse(responseCode = "401", description = "access token is invalid", content = @Content),
+        @ApiResponse(responseCode = "404", description = "subscription with given id doesn't exist", content = @Content),
+        @ApiResponse(responseCode = "500", description = "internal server error", content = @Content),
+    })
+    @NonNull
+    @GetMapping("/{subscriptionId}")
+    ResponseEntity<SubscriptionResponseV2> getSubscription(
+        @NonNull @AuthenticationPrincipal Long principalId,
+        @Valid @NotNull @Min(1) @PathVariable Long subscriptionId,
+        @Valid @NullOrNotBlank @Size(min = 3, max = 3) @RequestParam(value = "currency", required = false) String currency
+    ) {
+        try {
+            return ResponseEntity.ok(subscriptionService.getSubscription(principalId, subscriptionId, currency));
+        } catch (SubscriptionNotFoundException e) {
+            return ResponseEntity.notFound().build();
+        }
+    }
+
+    /**
+     * Redeems an issued gift card and creates a subscription for the authenticated user.
+     *
+     * @param giftCardCode must not be blank.
+     * @return the newly activated subscription on successful redemption of the gift card.
+     */
+    @Operation(summary = "Redeem a gift card")
+    @ApiResponses({
+        @ApiResponse(responseCode = "201"),
+        @ApiResponse(responseCode = "400", description = "request is not valid", content = @Content),
+        @ApiResponse(responseCode = "401", description = "access token is invalid", content = @Content),
+        @ApiResponse(responseCode = "404", description = "gift card doesn't exist", content = @Content),
+        @ApiResponse(responseCode = "409", description = "user already has an active subscription", content = @Content),
+        @ApiResponse(responseCode = "410", description = "gift card has expired", content = @Content),
+        @ApiResponse(responseCode = "422", description = "gift card has already been redeemed", content = @Content),
+        @ApiResponse(responseCode = "500", description = "internal server error", content = @Content),
+    })
+    @NonNull
+    @PostMapping("/giftCards/{giftCardCode}/redeem")
+    ResponseEntity<SubscriptionResponseV2> redeemGiftCard(
+        @NonNull @AuthenticationPrincipal Long principalId,
+        @Valid @NotBlank @Size(min = 1, max = 32) @PathVariable String giftCardCode
+    ) {
+        try {
+            return ResponseEntity.status(HttpStatus.CREATED).body(subscriptionService.redeemGiftCard(principalId, giftCardCode));
+        } catch (GiftCardNotFoundException e) {
+            return ResponseEntity.notFound().build();
+        } catch (DuplicateSubscriptionException e) {
+            return ResponseEntity.status(HttpStatus.CONFLICT).build();
+        } catch (GiftCardExpiredException e) {
+            return ResponseEntity.status(HttpStatus.GONE).build();
+        } catch (GiftCardRedeemedException e) {
+            return ResponseEntity.unprocessableEntity().build();
         }
     }
 }

--- a/src/main/java/com/trynoice/api/subscription/SubscriptionControllerV2.java
+++ b/src/main/java/com/trynoice/api/subscription/SubscriptionControllerV2.java
@@ -182,12 +182,13 @@ public class SubscriptionControllerV2 {
     })
     @NonNull
     @PostMapping("/giftCards/{giftCardCode}/redeem")
-    ResponseEntity<SubscriptionResponseV2> redeemGiftCard(
+    ResponseEntity<Void> redeemGiftCard(
         @NonNull @AuthenticationPrincipal Long principalId,
         @Valid @NotBlank @Size(min = 1, max = 32) @PathVariable String giftCardCode
     ) {
         try {
-            return ResponseEntity.status(HttpStatus.CREATED).body(subscriptionService.redeemGiftCard(principalId, giftCardCode));
+            subscriptionService.redeemGiftCard(principalId, giftCardCode);
+            return ResponseEntity.status(HttpStatus.CREATED).build();
         } catch (GiftCardNotFoundException e) {
             return ResponseEntity.notFound().build();
         } catch (DuplicateSubscriptionException e) {

--- a/src/main/java/com/trynoice/api/subscription/SubscriptionControllerV2.java
+++ b/src/main/java/com/trynoice/api/subscription/SubscriptionControllerV2.java
@@ -1,0 +1,91 @@
+package com.trynoice.api.subscription;
+
+import com.trynoice.api.subscription.exceptions.DuplicateSubscriptionException;
+import com.trynoice.api.subscription.exceptions.SubscriptionPlanNotFoundException;
+import com.trynoice.api.subscription.payload.SubscriptionFlowParams;
+import com.trynoice.api.subscription.payload.SubscriptionFlowResponseV2;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
+@Validated
+@RestController
+@RequestMapping("/v2/subscriptions")
+@Slf4j
+@Tag(name = "subscription")
+public class SubscriptionControllerV2 {
+
+    private final SubscriptionService subscriptionService;
+
+    @Autowired
+    SubscriptionControllerV2(@NonNull SubscriptionService subscriptionService) {
+        this.subscriptionService = subscriptionService;
+    }
+
+    /**
+     * <p>
+     * Initiates the subscription flow for the authenticated user. The flow might vary with payment
+     * providers. It creates a new {@code incomplete} subscription entity and returns it with the
+     * response on success.
+     *
+     * <p>To conclude this flow and transition the subscription entity to {@code active} state:</p>
+     *
+     * <ul>
+     *     <li>for Google Play plans, the clients must link {@code subscriptionId} with the
+     *     subscription purchase by specifying it as {@code obfuscatedAccountId} in Google Play
+     *     billing flow params.</li>
+     *     <li>for Stripe plans, the clients must redirect the user to the provided url to make the
+     *     payment and complete the checkout session.</li>
+     * </ul>
+     *
+     * <p>
+     * Since clients may desire to use created subscription's id in {@code successUrl} and {@code
+     * cancelUrl} callbacks, the server makes it available through {@code {subscriptionId}} template
+     * string in their values, e.g. {@code https://api.test/success?id={subscriptionId}}. The server
+     * will replace the template with the created subscription's id before creating a Stripe
+     * checkout session, i.e. it will transform the previous url to {@code
+     * https://api.test/success?id=1}, assuming the created subscription's id is {@literal 1}.</p>
+     *
+     * @param params {@code successUrl} and {@code cancelUrl} are only required for Stripe plans.
+     */
+    @Operation(summary = "Initiate the subscription flow")
+    @ApiResponses({
+        @ApiResponse(responseCode = "201", description = "subscription flow successfully initiated"),
+        @ApiResponse(responseCode = "400", description = "request is not valid", content = @Content),
+        @ApiResponse(responseCode = "401", description = "access token is invalid", content = @Content),
+        @ApiResponse(responseCode = "409", description = "user already has an active subscription", content = @Content),
+        @ApiResponse(responseCode = "500", description = "internal server error", content = @Content),
+    })
+    @NonNull
+    @PostMapping
+    ResponseEntity<SubscriptionFlowResponseV2> createSubscription(
+        @NonNull @AuthenticationPrincipal Long principalId,
+        @Valid @NotNull @RequestBody SubscriptionFlowParams params
+    ) {
+        try {
+            val response = subscriptionService.createSubscription(principalId, params);
+            return ResponseEntity.status(HttpStatus.CREATED).body(response);
+        } catch (SubscriptionPlanNotFoundException e) {
+            return ResponseEntity.badRequest().build();
+        } catch (DuplicateSubscriptionException e) {
+            return ResponseEntity.status(HttpStatus.CONFLICT).build();
+        }
+    }
+}

--- a/src/main/java/com/trynoice/api/subscription/SubscriptionService.java
+++ b/src/main/java/com/trynoice/api/subscription/SubscriptionService.java
@@ -28,7 +28,7 @@ import com.trynoice.api.subscription.payload.GiftCardResponse;
 import com.trynoice.api.subscription.payload.GooglePlayDeveloperNotification;
 import com.trynoice.api.subscription.payload.GooglePlaySubscriptionPurchase;
 import com.trynoice.api.subscription.payload.SubscriptionFlowParams;
-import com.trynoice.api.subscription.payload.SubscriptionFlowResponse;
+import com.trynoice.api.subscription.payload.SubscriptionFlowResponseV2;
 import com.trynoice.api.subscription.payload.SubscriptionPlanResponse;
 import com.trynoice.api.subscription.payload.SubscriptionResponse;
 import lombok.NonNull;
@@ -139,7 +139,7 @@ class SubscriptionService implements SubscriptionServiceContract {
      *
      * <p>
      * If the requested plan is provided by {@link SubscriptionPlan.Provider#STRIPE}, it also
-     * returns a non-null {@link SubscriptionFlowResponse#getStripeCheckoutSessionUrl() checkout
+     * returns a non-null {@link SubscriptionFlowResponseV2#getStripeCheckoutSessionUrl() checkout
      * session url}. The clients must redirect user to the checkout session url to conclude the
      * subscription flow.</p>
      *
@@ -151,13 +151,13 @@ class SubscriptionService implements SubscriptionServiceContract {
      *
      * @param customerId id of the customer (user) that initiated the subscription flow.
      * @param params     subscription flow parameters.
-     * @return a non-null {@link SubscriptionFlowResponse}.
+     * @return a non-null {@link SubscriptionFlowResponseV2}.
      * @throws SubscriptionPlanNotFoundException if the specified plan doesn't exist.
      * @throws DuplicateSubscriptionException    if the user already has an active/pending subscription.
      */
     @NonNull
     @Transactional(rollbackFor = Throwable.class)
-    public SubscriptionFlowResponse createSubscription(
+    public SubscriptionFlowResponseV2 createSubscription(
         @NonNull Long customerId,
         @NonNull SubscriptionFlowParams params
     ) throws SubscriptionPlanNotFoundException, DuplicateSubscriptionException {
@@ -185,8 +185,9 @@ class SubscriptionService implements SubscriptionServiceContract {
                 .plan(plan)
                 .build());
 
-        val result = new SubscriptionFlowResponse();
+        val result = new SubscriptionFlowResponseV2();
         result.setSubscription(buildSubscriptionResponse(subscription, null, null, null));
+        result.setSubscriptionId(subscription.getId());
         if (plan.getProvider() != SubscriptionPlan.Provider.STRIPE) {
             return result;
         }

--- a/src/main/java/com/trynoice/api/subscription/entities/Subscription.java
+++ b/src/main/java/com/trynoice/api/subscription/entities/Subscription.java
@@ -42,7 +42,7 @@ public class Subscription extends BasicEntity {
     @ManyToOne(optional = false)
     private SubscriptionPlan plan;
 
-    private String providerSubscriptionId;
+    private String providedId;
 
     private boolean isPaymentPending;
 

--- a/src/main/java/com/trynoice/api/subscription/entities/SubscriptionPlan.java
+++ b/src/main/java/com/trynoice/api/subscription/entities/SubscriptionPlan.java
@@ -35,7 +35,7 @@ public class SubscriptionPlan extends BasicEntity {
     private Provider provider;
 
     @NonNull
-    private String providerPlanId;
+    private String providedId;
 
     private short billingPeriodMonths;
 

--- a/src/main/java/com/trynoice/api/subscription/entities/SubscriptionPlanRepository.java
+++ b/src/main/java/com/trynoice/api/subscription/entities/SubscriptionPlanRepository.java
@@ -44,12 +44,12 @@ public interface SubscriptionPlanRepository extends BasicEntityRepository<Subscr
     /**
      * Find a subscription plan by its provider plan id.
      *
-     * @param provider it must be a non-null {@link SubscriptionPlan.Provider}.
-     * @param planId   plan id assigned by the provider. It must be a non-null string.
+     * @param provider   it must be a non-null {@link SubscriptionPlan.Provider}.
+     * @param providedId plan id assigned by the provider. It must be a non-null string.
      * @return a non-empty optional if such a subscription plan exists in the repository.
      */
     @NonNull
     @Transactional(readOnly = true)
-    @Query("select e from SubscriptionPlan e where e.provider = ?1 and e.providerPlanId = ?2 and" + WHERE_ACTIVE_CLAUSE)
-    Optional<SubscriptionPlan> findByProviderPlanId(@NonNull SubscriptionPlan.Provider provider, @NonNull String planId);
+    @Query("select e from SubscriptionPlan e where e.provider = ?1 and e.providedId = ?2 and" + WHERE_ACTIVE_CLAUSE)
+    Optional<SubscriptionPlan> findByProvidedId(@NonNull SubscriptionPlan.Provider provider, @NonNull String providedId);
 }

--- a/src/main/java/com/trynoice/api/subscription/entities/SubscriptionRepository.java
+++ b/src/main/java/com/trynoice/api/subscription/entities/SubscriptionRepository.java
@@ -21,13 +21,13 @@ public interface SubscriptionRepository extends BasicEntityRepository<Subscripti
     /**
      * Find a {@link Subscription} entity by its provider assigned subscription id.
      *
-     * @param providerSubscriptionId it must be a non-null provider assigned subscription id.
+     * @param providedId it must be a non-null provider assigned subscription id.
      * @return an optional {@link Subscription} entity.
      */
     @NonNull
     @Transactional(readOnly = true)
-    @Query("select e from Subscription e where e.providerSubscriptionId = ?1 and" + WHERE_ACTIVE_CLAUSE)
-    Optional<Subscription> findByProviderSubscriptionId(@NonNull String providerSubscriptionId);
+    @Query("select e from Subscription e where e.providedId = ?1 and" + WHERE_ACTIVE_CLAUSE)
+    Optional<Subscription> findByProvidedId(@NonNull String providedId);
 
     /**
      * Checks whether an active subscription ({@code startAt < now() < endAt}) exists with the given

--- a/src/main/java/com/trynoice/api/subscription/exceptions/StripeCustomerPortalUrlException.java
+++ b/src/main/java/com/trynoice/api/subscription/exceptions/StripeCustomerPortalUrlException.java
@@ -1,0 +1,7 @@
+package com.trynoice.api.subscription.exceptions;
+
+/**
+ * Thrown by getStripeCustomerPortalUrl operation in SubscriptionService.
+ */
+public class StripeCustomerPortalUrlException extends Exception {
+}

--- a/src/main/java/com/trynoice/api/subscription/exceptions/UnsupportedSubscriptionPlanProviderException.java
+++ b/src/main/java/com/trynoice/api/subscription/exceptions/UnsupportedSubscriptionPlanProviderException.java
@@ -6,10 +6,6 @@ package com.trynoice.api.subscription.exceptions;
  */
 public class UnsupportedSubscriptionPlanProviderException extends Exception {
 
-    public UnsupportedSubscriptionPlanProviderException(String message) {
-        super(message);
-    }
-
     public UnsupportedSubscriptionPlanProviderException(Throwable cause) {
         super(cause);
     }

--- a/src/main/java/com/trynoice/api/subscription/payload/StripeCustomerPortalUrlResponse.java
+++ b/src/main/java/com/trynoice/api/subscription/payload/StripeCustomerPortalUrlResponse.java
@@ -1,0 +1,15 @@
+package com.trynoice.api.subscription.payload;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NonNull;
+
+@Data
+@Builder
+public class StripeCustomerPortalUrlResponse {
+
+    @Schema(required = true, description = "short-lived URL of the session that provides access to the customer portal.")
+    @NonNull
+    private String url;
+}

--- a/src/main/java/com/trynoice/api/subscription/payload/SubscriptionFlowResponseV2.java
+++ b/src/main/java/com/trynoice/api/subscription/payload/SubscriptionFlowResponseV2.java
@@ -1,24 +1,22 @@
 package com.trynoice.api.subscription.payload;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.NonNull;
 
 /**
  * A data transfer object to send subscription flow details back to the SubscriptionController.
  */
 @Data
-@Builder
 @NoArgsConstructor
-@AllArgsConstructor
-public class SubscriptionFlowResponse {
+public class SubscriptionFlowResponseV2 {
 
-    @Schema(required = true, description = "the newly created subscription")
-    @NonNull
+    @JsonIgnore
     private SubscriptionResponse subscription;
+
+    @Schema(required = true, description = "id of the newly created subscription")
+    private long subscriptionId;
 
     @Schema(description = "Checkout url for billing this subscription. Only present if the provider is 'stripe'")
     private String stripeCheckoutSessionUrl;

--- a/src/main/java/com/trynoice/api/subscription/payload/SubscriptionFlowResponseV2.java
+++ b/src/main/java/com/trynoice/api/subscription/payload/SubscriptionFlowResponseV2.java
@@ -13,7 +13,7 @@ import lombok.NoArgsConstructor;
 public class SubscriptionFlowResponseV2 {
 
     @JsonIgnore
-    private SubscriptionResponse subscription;
+    private SubscriptionResponseV2 subscription;
 
     @Schema(required = true, description = "id of the newly created subscription")
     private long subscriptionId;

--- a/src/main/java/com/trynoice/api/subscription/payload/SubscriptionResponseV2.java
+++ b/src/main/java/com/trynoice/api/subscription/payload/SubscriptionResponseV2.java
@@ -1,0 +1,59 @@
+package com.trynoice.api.subscription.payload;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+
+import java.time.OffsetDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(name = "SubscriptionV2")
+public class SubscriptionResponseV2 {
+
+    @Schema(required = true, description = "id of the subscription purchase")
+    @NonNull
+    private Long id;
+
+    @Schema(required = true, description = "plan associated with this subscription purchase")
+    @NonNull
+    private SubscriptionPlanResponse plan;
+
+    @Schema(required = true, description = "whether this subscription purchase is currently active")
+    @NonNull
+    private Boolean isActive;
+
+    @Schema(required = true, description = "whether a payment for this subscription purchase is currently pending")
+    @NonNull
+    private Boolean isPaymentPending;
+
+    @Schema(type = "integer", format = "int64", description = "epoch millis when the subscription started")
+    private OffsetDateTime startedAt;
+
+    @Schema(type = "integer", format = "int64", description = "epoch millis when the subscription ended")
+    private OffsetDateTime endedAt;
+
+    @Schema(required = true, description = "whether the subscription will renew at the end of this billing " +
+        "cycle. if false, it implies that the subscription will end at the end of current billing cycle.")
+    @NonNull
+    private Boolean isAutoRenewing;
+
+    @Schema(description = "whether the subscription was cancelled and its amount refunded.")
+    private Boolean isRefunded;
+
+    @Schema(type = "integer", format = "int64", description = "epoch millis when the current billing cycle ends " +
+        "and the next one starts. always present unless the subscription is inactive.")
+    private OffsetDateTime renewsAt;
+
+    @Schema(description = "purchase token corresponding to this subscription purchase. only present when the " +
+        "subscription is active and provided by Google Play")
+    private String googlePlayPurchaseToken;
+
+    @Schema(description = "the gift card code if this subscription was activated using a gift card.")
+    private String giftCardCode;
+}

--- a/src/main/resources/db/migration/common/V3__Rename_provided_id_columns.sql
+++ b/src/main/resources/db/migration/common/V3__Rename_provided_id_columns.sql
@@ -1,0 +1,3 @@
+ALTER TABLE subscription_plan RENAME provider_plan_id TO provided_id;
+ALTER TABLE subscription RENAME provider_subscription_id TO provided_id;
+ALTER INDEX subscription__provider_subscription_id__unique_idx RENAME TO subscription__provided_id__unique_idx;

--- a/src/test/java/com/trynoice/api/subscription/SubscriptionServiceTest.java
+++ b/src/test/java/com/trynoice/api/subscription/SubscriptionServiceTest.java
@@ -282,12 +282,12 @@ public class SubscriptionServiceTest {
         lenient().when(exchangeRatesProvider.getRateForCurrency(any(), any()))
             .thenReturn(Optional.of(1.0));
 
-        val result1 = service.listSubscriptions(userId1, false, null, null, 0);
+        val result1 = service.listSubscriptions(userId1, false, null, 0);
         assertEquals(1, result1.size());
         assertEquals(subscription1.getId(), result1.get(0).getId());
         assertNull(result1.get(0).getPlan().getPriceInRequestedCurrency());
 
-        val result2 = service.listSubscriptions(userId2, false, null, "USD", 0);
+        val result2 = service.listSubscriptions(userId2, false, "USD", 0);
         assertEquals(1, result2.size());
         assertEquals(subscription2.getId(), result2.get(0).getId());
         assertNotNull(result2.get(0).getPlan().getPriceInRequestedCurrency());

--- a/src/test/java/com/trynoice/api/subscription/SubscriptionServiceTest.java
+++ b/src/test/java/com/trynoice/api/subscription/SubscriptionServiceTest.java
@@ -158,7 +158,7 @@ public class SubscriptionServiceTest {
                 assertEquals(requestingCurrencyCode, got.getRequestedCurrencyCode());
                 assertEquals(
                     expecting.getProvider() == SubscriptionPlan.Provider.GOOGLE_PLAY
-                        ? expecting.getProviderPlanId()
+                        ? expecting.getProvidedId()
                         : null,
                     got.getGooglePlaySubscriptionId());
             }
@@ -316,11 +316,11 @@ public class SubscriptionServiceTest {
             switch (subscription.getPlan().getProvider()) {
                 case GOOGLE_PLAY:
                     verify(androidPublisherApi, times(1))
-                        .cancelSubscription(subscription.getProviderSubscriptionId());
+                        .cancelSubscription(subscription.getProvidedId());
                     break;
                 case STRIPE:
                     verify(stripeApi, times(1))
-                        .cancelSubscription(subscription.getProviderSubscriptionId());
+                        .cancelSubscription(subscription.getProvidedId());
                     break;
                 default:
                     throw new RuntimeException("unknown provider");
@@ -438,10 +438,10 @@ public class SubscriptionServiceTest {
     }
 
     @NonNull
-    private static SubscriptionPlan buildSubscriptionPlan(@NonNull SubscriptionPlan.Provider provider, @NonNull String providerPlanId) {
+    private static SubscriptionPlan buildSubscriptionPlan(@NonNull SubscriptionPlan.Provider provider, @NonNull String providedId) {
         val plan = SubscriptionPlan.builder()
             .provider(provider)
-            .providerPlanId(providerPlanId)
+            .providedId(providedId)
             .billingPeriodMonths((short) 2)
             .trialPeriodDays((short) 1)
             .priceInIndianPaise(22500)
@@ -463,7 +463,7 @@ public class SubscriptionServiceTest {
             .id(Math.round(Math.random() * 1000))
             .customer(Customer.builder().userId(ownerId).build())
             .plan(plan)
-            .providerSubscriptionId(UUID.randomUUID().toString())
+            .providedId(UUID.randomUUID().toString())
             .isPaymentPending(isPaymentPending)
             .startAt(now.plusHours(-2))
             .endAt(now.plusHours(isActive ? 2 : -1))


### PR DESCRIPTION
- Add v2 endpoints that remove `stripeReturnUrl` request parameter and `stripeCustomerPortalUrl` response field from subscription endpoints.